### PR TITLE
fix build errors aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -35,6 +35,7 @@
 
 #include OS_HEADER_INLINE(os)
 
+#ifndef BUILTIN_SIM
 #if defined (__linux__)
 #include <sys/auxv.h>
 #include <asm/hwcap.h>

--- a/src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp
@@ -25,10 +25,10 @@
 
 #include "precompiled.hpp"
 #include "runtime/os.hpp"
-#include "runtime/vm_version.hpp"
+#include "vm_version_aarch64.hpp"
 
-#if defined (__FreeBSD__)
 #include <machine/armreg.h>
+#if defined (__FreeBSD__)
 #include <machine/elf.h>
 #endif
 
@@ -74,6 +74,22 @@
 
 #ifndef ID_AA64PFR0_AdvSIMD_HP
 #define ID_AA64PFR0_AdvSIMD_HP (UL(0x1) << ID_AA64PFR0_AdvSIMD_SHIFT)
+#endif
+
+#ifndef ID_AA64ISAR0_AES_VAL
+#define ID_AA64ISAR0_AES_VAL ID_AA64ISAR0_AES
+#endif
+
+#ifndef ID_AA64ISAR0_SHA1_VAL
+#define ID_AA64ISAR0_SHA1_VAL ID_AA64ISAR0_SHA1
+#endif
+
+#ifndef ID_AA64ISAR0_SHA2_VAL
+#define ID_AA64ISAR0_SHA2_VAL ID_AA64ISAR0_SHA2
+#endif
+
+#ifndef ID_AA64ISAR0_CRC32_VAL
+#define ID_AA64ISAR0_CRC32_VAL ID_AA64ISAR0_CRC32
 #endif
 
 #define	CPU_IMPL_ARM		0x41
@@ -186,6 +202,17 @@ const struct cpu_implementers cpu_implementers[] = {
 	CPU_IMPLEMENTER_NONE,
 };
 
+#ifdef __OpenBSD__
+// READ_SPECIALREG is not available from userland on OpenBSD.
+// Hardcode these values to the "lowest common denominator"
+unsigned long VM_Version::os_get_processor_features() {
+  _cpu = CPU_IMPL_ARM;
+  _model = CPU_PART_CORTEX_A53;
+  _variant = 0;
+  _revision = 0;
+  return HWCAP_ASIMD;
+}
+#else
 unsigned long VM_Version::os_get_processor_features() {
   struct cpu_desc cpu_desc[1];
   struct cpu_desc user_cpu_desc;
@@ -229,26 +256,26 @@ unsigned long VM_Version::os_get_processor_features() {
   _model = cpu_desc[cpu].cpu_part_num;
   _revision = cpu_desc[cpu].cpu_revision;
 
-  id_aa64isar0 = READ_SPECIALREG(ID_AA64ISAR0_EL1);
-  id_aa64pfr0 = READ_SPECIALREG(ID_AA64PFR0_EL1);
+  id_aa64isar0 = READ_SPECIALREG(id_aa64isar0_el1);
+  id_aa64pfr0 = READ_SPECIALREG(id_aa64pfr0_el1);
 
-  if (ID_AA64ISAR0_AES(id_aa64isar0) == ID_AA64ISAR0_AES_BASE) {
+  if (ID_AA64ISAR0_AES_VAL(id_aa64isar0) == ID_AA64ISAR0_AES_BASE) {
     auxv = auxv | HWCAP_AES;
   }
 
-  if (ID_AA64ISAR0_AES(id_aa64isar0) == ID_AA64ISAR0_AES_PMULL) {
+  if (ID_AA64ISAR0_AES_VAL(id_aa64isar0) == ID_AA64ISAR0_AES_PMULL) {
     auxv = auxv | HWCAP_PMULL;
   }
 
-  if (ID_AA64ISAR0_SHA1(id_aa64isar0) == ID_AA64ISAR0_SHA1_BASE) {
+  if (ID_AA64ISAR0_SHA1_VAL(id_aa64isar0) == ID_AA64ISAR0_SHA1_BASE) {
     auxv = auxv | HWCAP_SHA1;
   }
 
-  if (ID_AA64ISAR0_SHA2(id_aa64isar0) == ID_AA64ISAR0_SHA2_BASE) {
+  if (ID_AA64ISAR0_SHA2_VAL(id_aa64isar0) == ID_AA64ISAR0_SHA2_BASE) {
     auxv = auxv | HWCAP_SHA2;
   }
 
-  if (ID_AA64ISAR0_CRC32(id_aa64isar0) == ID_AA64ISAR0_CRC32_BASE) {
+  if (ID_AA64ISAR0_CRC32_VAL(id_aa64isar0) == ID_AA64ISAR0_CRC32_BASE) {
     auxv = auxv | HWCAP_CRC32;
   }
 
@@ -259,3 +286,4 @@ unsigned long VM_Version::os_get_processor_features() {
 
   return auxv;
 }
+#endif


### PR DESCRIPTION
root@generic:/usr/local/openjdk14 # uname -a
FreeBSD generic 13.0-CURRENT FreeBSD 13.0-CURRENT #19 71703cd8836-c267543(master): Fri Mar 20 23:34:10 UTC 2020     root@generic:/usr/obj/usr/src/arm64.aarch64/sys/GENERIC-NODEBUG  arm64
root@generic:/usr/local/openjdk14 # bin/java -version
openjdk version "14" 2020-03-17
OpenJDK Runtime Environment (build 14+36-1)
OpenJDK 64-Bit Server VM (build 14+36-1, mixed mode, sharing)